### PR TITLE
Entrega de Atividades - Davih G. Duque

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -8,7 +8,7 @@ android {
     defaultConfig {
         applicationId "br.ufmg.coltec.topicos_e04_backgroundtasks"
         minSdk 23
-        targetSdk 32
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -29,9 +29,12 @@ android {
 
 dependencies {
 
-    implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'com.google.android.material:material:1.4.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+
+    implementation 'androidx.appcompat:appcompat:1.6.0'
+    implementation 'androidx.core:core-ktx:1.10.0'
+
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'

--- a/app/src/main/java/br/ufmg/coltec/topicos_e04_backgroundtasks/ImageDownloader.java
+++ b/app/src/main/java/br/ufmg/coltec/topicos_e04_backgroundtasks/ImageDownloader.java
@@ -1,10 +1,5 @@
 package br.ufmg.coltec.topicos_e04_backgroundtasks;
 
-/**
- * Classe retirada do livro Google Android, 3a edição
- * @author R. Lecheta
- */
-
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 
@@ -14,6 +9,7 @@ import java.net.URL;
 
 public class ImageDownloader {
 
+    // Método responsável por baixar a imagem
     public static Bitmap download(String url) throws IOException {
         Bitmap bitmap = null;
 
@@ -21,6 +17,6 @@ public class ImageDownloader {
         bitmap = BitmapFactory.decodeStream(inputStream);
         inputStream.close();
 
-        return  bitmap;
+        return bitmap;
     }
 }

--- a/app/src/main/java/br/ufmg/coltec/topicos_e04_backgroundtasks/MainActivity.java
+++ b/app/src/main/java/br/ufmg/coltec/topicos_e04_backgroundtasks/MainActivity.java
@@ -1,5 +1,4 @@
 package br.ufmg.coltec.topicos_e04_backgroundtasks;
-import androidx.appcompat.app.AppCompatActivity;
 
 import android.graphics.Bitmap;
 import android.os.Bundle;
@@ -8,10 +7,16 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
+
+import androidx.appcompat.app.AppCompatActivity;
 
 import java.io.IOException;
 
 public class MainActivity extends AppCompatActivity {
+
+    private ProgressBar progressBar;
+    private ImageView imgView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -20,25 +25,54 @@ public class MainActivity extends AppCompatActivity {
 
         Button downloadBtn = findViewById(R.id.btn_download);
         EditText txtLink = findViewById(R.id.txt_img_link);
-        ImageView imgView = findViewById(R.id.img_picture);
+        imgView = findViewById(R.id.img_picture);
+        progressBar = findViewById(R.id.progress_bar);
 
-//        TODO[1]: Processo de download e carregamento da imagem acontecendo na Main Thread, ALTERAR!!
         downloadBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
-                // TODO[2]: Exibir barra de progresso quando estiver fazendo download da imagem
-                Bitmap img = MainActivity.this.downloadImage(txtLink.getText().toString());
-                imgView.setImageBitmap(img);
+                // Exibe a barra de progresso enquanto a imagem está sendo baixada
+                progressBar.setVisibility(View.VISIBLE);
+
+                // Esconde a imagem durante o download
+                imgView.setVisibility(View.GONE);
+                String imageUrl = txtLink.getText().toString();
+
+                // Inicia uma nova Thread para o download da imagem
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        try {
+                            // Baixa a imagem usando a classe ImageDownloader
+                            Bitmap img = ImageDownloader.download(imageUrl);
+
+                            // Atualiza a UI na thread principal após o download
+                            runOnUiThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    progressBar.setVisibility(View.GONE);
+                                    if (img != null) {
+                                        imgView.setImageBitmap(img);
+                                        imgView.setVisibility(View.VISIBLE);
+                                    } else {
+                                        Log.e("MainActivity", "Falha ao carregar a imagem.");
+                                    }
+                                }
+                            });
+                        } catch (IOException e) {
+                            Log.e("MainActivity", "Erro ao baixar a imagem: " + e.getMessage());
+
+                            // Esconder a barra de progresso em caso de erro
+                            runOnUiThread(new Runnable() {
+                                @Override
+                                public void run() {
+                                    progressBar.setVisibility(View.GONE);
+                                }
+                            });
+                        }
+                    }
+                }).start();
             }
         });
-    }
-
-    private Bitmap downloadImage(String imgLink) {
-        try {
-            return ImageDownloader.download(imgLink);
-        } catch (IOException e) {
-            Log.e("MainActivity", e.toString());
-            return null;
-        }
     }
 }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,35 +1,48 @@
-<?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    android:padding="15dp"
-    tools:context=".MainActivity">
+    android:layout_height="match_parent">
 
+    <!-- Imagem exibida após o download -->
+    <ImageView
+        android:id="@+id/img_picture"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:scaleType="fitCenter"
+        android:visibility="gone" />
+
+    <!-- Barra de progresso para exibir durante o download -->
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:visibility="gone"
+        android:layout_gravity="center" />
+
+    <!-- Layout para entrada de URL -->
     <LinearLayout
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:orientation="horizontal">
-        <EditText
-            android:layout_width="wrap_content"
+
+        android:orientation="horizontal"
+        android:layout_gravity="top|center_horizontal"
+        android:padding="15dp">
+
+        <EditText android:id="@+id/txt_img_link"
+
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
-            android:id="@+id/txt_img_link" />
 
-        <Button
+            android:hint="Insira a URL da Imagem" />
+
+        <Button  android:id="@+id/btn_download"
+
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="Download"
-            android:id="@+id/btn_download" />
-    </LinearLayout>
-    <ImageView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_gravity="center"
-        android:layout_weight="1"
-        android:id="@+id/img_picture" />
 
-    <!-- TODO[2] Incluir ProgressBar para exibir durante download da imagem -->
-</LinearLayout>
+            android:text="Download" />
+    </LinearLayout>
+
+</FrameLayout>


### PR DESCRIPTION
A aplicação não funcionou de jeito nenhum com minhas alterações.

Então considerar esse repositório cópia 

https://github.com/DevDuque/BackgroundTasks

O erro presente era o NetworkOnMainThreadException

A thread principal é responsável por renderizar a interface do usuário e processar as interações do usuário. Executar tarefas longas, como baixar uma imagem, na thread principal faz com que o aplicativo fique bloqueado até que a operação de rede seja concluída, o que leva a uma experiência ruim do usuário. Por isso, o Android não permite que operações de rede sejam executadas na thread principal. Para evitar o NetworkOnMainThreadException, é necessário mover essas operações para uma thread em segundo plano