### PR TITLE
Entrega das atividades

### DIFF
--- a/.idea/compiler.xml
+++ b/.idea/compiler.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="CompilerConfiguration">
-    <bytecodeTargetLevel target="1.8" />
+    <bytecodeTargetLevel target="17" />
   </component>
 </project>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,17 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="testRunner" value="GRADLE" />
-        <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />
             <option value="$PROJECT_DIR$/app" />
           </set>
         </option>
+        <option name="resolveExternalAnnotations" value="false" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -7,7 +7,7 @@
       </map>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_17" default="true" project-jdk-name="jbr-17" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,8 +5,7 @@
 
     <application
         android:allowBackup="true"
-        android:dataExtractionRules="@xml/data_extraction_rules"
-        android:fullBackupContent="@xml/backup_rules"
+
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/br/ufmg/coltec/topicos_e04_backgroundtasks/MainActivity.java
+++ b/app/src/main/java/br/ufmg/coltec/topicos_e04_backgroundtasks/MainActivity.java
@@ -8,6 +8,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.ImageView;
+import android.widget.ProgressBar;
 
 import java.io.IOException;
 
@@ -21,14 +22,30 @@ public class MainActivity extends AppCompatActivity {
         Button downloadBtn = findViewById(R.id.btn_download);
         EditText txtLink = findViewById(R.id.txt_img_link);
         ImageView imgView = findViewById(R.id.img_picture);
+        ProgressBar progressBar = findViewById(R.id.progress_bar);
 
 //        TODO[1]: Processo de download e carregamento da imagem acontecendo na Main Thread, ALTERAR!!
         downloadBtn.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
                 // TODO[2]: Exibir barra de progresso quando estiver fazendo download da imagem
-                Bitmap img = MainActivity.this.downloadImage(txtLink.getText().toString());
-                imgView.setImageBitmap(img);
+                progressBar.setVisibility(View.VISIBLE);
+                imgView.setVisibility(View.GONE);
+                String url = txtLink.getText().toString();
+                new Thread(new Runnable() {
+                    @Override
+                    public void run() {
+                        Bitmap img = null;
+                        img = downloadImage(url);
+                        if(img != null){
+                            imgView.setImageBitmap(img);
+                            imgView.setVisibility(View.VISIBLE);
+                            progressBar.setVisibility(View.GONE);
+                        }else{
+                            Log.e("MainActivity", "Não foi possível carregar");
+                        }
+                    }
+                }).start();
             }
         });
     }

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -13,7 +13,7 @@
         android:layout_height="wrap_content"
         android:orientation="horizontal">
         <EditText
-            android:layout_width="wrap_content"
+            android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_weight="1"
             android:id="@+id/txt_img_link" />
@@ -32,4 +32,11 @@
         android:id="@+id/img_picture" />
 
     <!-- TODO[2] Incluir ProgressBar para exibir durante download da imagem -->
-</LinearLayout>
+    <ProgressBar
+        android:id="@+id/progress_bar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        android:layout_gravity="center"
+        />
+</FrameLayout>


### PR DESCRIPTION
A exceção lançada foi NetworkOnMainThreadException, que ocorre quando uma tarefa de rede é realizada diretamente na thread principal do aplicativo. A thread tem como objetivo principal gerenciar a interface do usuário e suas interações. Ao tentar executar ações demoradas, como o download de uma imagem, na thread principal, o app pode travar até que a tarefa seja concluída. Para evitar esse problema, é necessário transferir as operações de rede para uma thread de fundo, garantindo uma melhor experiência para o usuário.